### PR TITLE
Use compatible version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,7 @@ runs:
       id: buildx
       uses: docker/setup-buildx-action@v1
       with:
+        version: v0.8.2
         driver-opts: network=host
     - if: fromJson(inputs.registry) || fromJson(inputs.shared)
       uses: actions/cache@v3


### PR DESCRIPTION
Fix to the previous version because buildx was broken at the latest version.